### PR TITLE
Landing Page Update

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,11 @@
---8<-- "README.md"
+<!--- --8<-- "README.md" --->
 
-# Welcome to MkDocs
+# E4S-Pro
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+The Extreme-scale Scientific Software Stack [(E4S)][1] is a broad collection of HPC focused [software packages][2]. E4S provides a unified computing environment for deployment of open-source projects. E4S includes contributions from many organizations, including national laboratories, universities, and industry. E4S packages are deployed and managed via [Spack][3]. E4S was originally developed to provide a common software environment for the exascale leadership computing systems currently being deployed at DOE National Laboratories across the U.S. 
 
-## Commands
+E4S-Pro takes E4S and deploys it to containers that are hardened and optimized for use on commercial clouds. It adds additional valuable features such as enhanced MPI performance, a performant remote desktop interface, and extra, optimized software packages for a variety of AI and other HPC applications. E4S-Pro also adds deployment and development support from ParaTools, Inc. E4S-Pro is supported by the U.S. Department of Energy's SBIR program.
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
-
-## Project layout
-
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+[1]: https://www.e4s.io
+[2]: https://e4s-project.github.io/DocPortal.html
+[3]: https://github.com/spack/spack


### PR DESCRIPTION
I'm not going to treat this as a draft in case we want to get something else up right away, but there is additional work to be done here. In particular, linking to both AWS and GCP images. We have a link for the AWS marketplace: https://aws.amazon.com/marketplace/pp/prodview-xprkx44kyqgp6 but I can't find anything equivalent form google. This was the closest I found it doesn't seem especially helpful as a user facing document: https://console.cloud.google.com/compute/instanceTemplates/list?project=e4s-pro

This page should go into more detail on the support for AWS and GCP respectively but I want to check up on feature parity before I do that. 